### PR TITLE
Fixed the propositions bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ game.layout
 /workspaces/.vs/game/v16/Browse.VC.db
 /workspaces/gamelog.txt
 /workspaces/xmllog
+/workspaces

--- a/src/politics/politics.h
+++ b/src/politics/politics.h
@@ -28,6 +28,9 @@ void amnesty();
 char wincheck();
 /* politics - checks the prevailing attitude on a specific law, or overall */
 int publicmood(int l);
+/* politics - checks the public's interest in a specific law, or overall*/
+int publicinterest(int i);
+
 /* returns true if Stalinists agree with Elite Liberals on a view/law, false if they strongly disagree with libs  *
  * the input bool islaw, if true, returns Stalinist opinion on laws, if false, returns Stalinist opinion on views */
 bool stalinview(short view, bool islaw);


### PR DESCRIPTION
Fixed the bug where liberal views weren't affecting propositions, along with some other minor mistakes. The bug was actually affecting almost everywhere the public's opinions mattered, so some balance changes may be needed.

Added a function to evaluate the public's interest in a given law. On a related note, legislators now factor in the intensity of the spotlight on the issue in question when proposing bills and casting their votes. Specifically, the intent of a bill is more strongly affected by the public when the public is extremely interested in the issue, and bills on hot topics also are made a higher priority. When it comes time to vote, now even arch-conservatives and elite-liberals have a chance of voting conservative and liberal respectively if interest levels are high enough. Conversely, at low interest levels, liberals and conservatives ignore any desires the public might have that might make them vote moderately.