### PR TITLE
Mask Overhaul, Newspaper crime handling, and Black Bloc Outfits.

### DIFF
--- a/art/armors.xml
+++ b/art/armors.xml
@@ -176,6 +176,50 @@
         <qualitylevels>3</qualitylevels>
         <durability>20</durability>
     </armortype>
+			
+	<armortype idname="ARMOR_BLACKBLOC">
+        <make_difficulty>7</make_difficulty>
+        <make_price>350</make_price>
+        <armor>
+            <body>3</body>
+            <limbs>2</limbs>
+			<head>1</head>
+        </armor>
+        <body_covering>
+            <head>true</head>
+			<body>true</body>
+            <arms>true</arms>
+            <legs>true</legs>
+            <conceals_face>true</conceals_face>
+        </body_covering>
+        <name>Armored Black Bloc Outfit</name>
+        <shortname>Blck B. Armor</shortname>
+        <fencevalue>100</fencevalue>
+        <professionalism>2</professionalism>
+        <stealth_value>3</stealth_value>
+		<conceal_weapon_size>5</conceal_weapon_size>
+        <qualitylevels>3</qualitylevels>
+        <durability>20</durability>
+    </armortype>
+    
+	<armortype idname="OUTFIT_BLACKBLOC">
+        <make_difficulty>1</make_difficulty>
+        <make_price>30</make_price>
+		<body_covering>
+            <head>true</head>
+			<body>true</body>
+            <arms>true</arms>
+            <legs>true</legs>
+            <conceals_face>true</conceals_face>
+        </body_covering>
+        <name>Black Bloc Outfit</name>
+        <shortname>Blck B. Outfit</shortname>
+        <fencevalue>5</fencevalue>
+        <professionalism>2</professionalism>
+        <stealth_value>3</stealth_value>
+		<conceal_weapon_size>5</conceal_weapon_size>
+        <qualitylevels>2</qualitylevels>
+    </armortype>
 
     <armortype idname="ARMOR_BLACKROBE">
         <make_difficulty>5</make_difficulty>

--- a/art/talk/MaskLines.txt
+++ b/art/talk/MaskLines.txt
@@ -1,0 +1,5 @@
+"Why are you hiding your face...?"
+"Are you ugly behind that mask?"
+"Oh look, a masked weirdo."
+"You look kinda creepy..."
+"Is it Halloween?"

--- a/src/common/commonactions.h
+++ b/src/common/commonactions.h
@@ -3,6 +3,8 @@
 void criminalizeparty(short crime);
 /* common - applies a crime to everyone in a location, or the entire LCS */
 void criminalizepool(short crime, long exclude = -1, short loc = -1);
+/* common - modified criminalize pool to only target newspaper writers */
+void criminalizepress(short crime, long exclude = -1, short loc = -1);
 /* common - gives juice to everyone in the active party */
 void juiceparty(long juice, long cap);
 /* common - purges empty squads from existance */

--- a/src/common/creaturePool.cpp
+++ b/src/common/creaturePool.cpp
@@ -1523,6 +1523,25 @@ void criminalizepool(short crime, long exclude, short loc)
 		criminalize(*pool[p], crime);
 	}
 }
+
+// More accurate treason criminalization for Newspaper writers.
+void criminalizepress(short crime, long exclude, short loc)
+{
+	bool has_writers = 0;
+	for (int p = 0; p < CreaturePool::getInstance().lenpool(); p++)
+	{
+		if (p == exclude) continue;
+		if (loc != -1 && pool[p]->location != loc) continue;
+		if (pool[p]->activity_type() == ACTIVITY_WRITE_GUARDIAN) {
+			criminalize(*pool[p], crime);
+			has_writers = 1;
+		}
+	}
+	// If no writers, criminalize locations.
+	if (!has_writers)
+		criminalizepool(crime, exclude, loc);
+}
+
 /* common - gives juice to a given creature */
 void addjuice(DeprecatedCreature &cr, long juice, long cap)
 {

--- a/src/constStringOEMcursesAlternative.h
+++ b/src/constStringOEMcursesAlternative.h
@@ -362,6 +362,7 @@ const string CONST_NORMAL_TALK_TO_MUTANT_TXT = "normal_talk_to_mutant.txt";
 const string CONST_LOVINGLY_TALK_TO_MUTANT_TXT = "lovingly_talk_to_mutant.txt";
 const string CONST_PICKUPLINES_TXT = "pickupLines.txt";
 const string CONST_NO_FREE_SPEECH_FLIRT_TXT = "no_free_speech_flirt.txt";
+const string CONST_WEIRDMASK_TXT = "MaskLines.txt"; //Maybe we can add variation later, idk.
 
 const string talky = "talk\\";
 const string talk_combat = "talk_combat\\";

--- a/src/creature/creature.h
+++ b/src/creature/creature.h
@@ -116,6 +116,7 @@ public:
 	bool will_reload(bool force_ranged, bool force_melee) const;
 	int count_clips() const;
 	int count_weapons() const;
+	bool face_is_concealed() const { return get_armor().conceals_face(); }
 	bool weapon_is_concealed() const { return is_armed() && get_armor().conceals_weaponsize(weapon->get_size()); }
 	string get_weapon_string(int subtype) const;
 	string get_armor_string(bool fullname) const { return get_armor().equip_title(fullname); }
@@ -169,7 +170,13 @@ public:
 		int lawflagheat(int lawflag);
 		crimes_suspected[crime]++;
 		if (grant_heat) {
-			heat += lawflagheat(crime);
+			// Gives less heat if liberal has their face concealed //
+			if (face_is_concealed() && activity_type() != ACTIVITY_WRITE_GUARDIAN && activity_type() != ACTIVITY_HACKING && activity_type() != ACTIVITY_CCFRAUD) {
+				heat += lawflagheat(crime) / 4;
+			}
+			else {
+				heat += lawflagheat(crime);
+			}
 
 		}
 	}

--- a/src/cursesAlternative.cpp
+++ b/src/cursesAlternative.cpp
@@ -3418,6 +3418,7 @@ extern vector<vector<string> > normal_talk_to_mutant;
 extern vector<vector<string> > lovingly_talk_to_dog;
 extern vector<vector<string> > normal_talk_to_dog;
 
+vector<string> WeirdMask;
 vector<string> dog_rejection;
 vector<string> mutant_rejection;
 vector<string> that_is_disturbing;
@@ -3445,6 +3446,7 @@ vector<file_and_text_collection> talk_file_collection = {
 	customText(&lovingly_talk_to_dog, talky + CONST_LOVINGLY_TALK_TO_DOG_TXT, DOUBLE_LINE),
 	customText(&normal_talk_to_dog, talky + CONST_NORMAL_TALK_TO_DOG_TXT, DOUBLE_LINE),
 	customText(&dog_rejection, talky + CONST_DOG_REJECTION_TXT),
+	customText(&WeirdMask, talky + CONST_WEIRDMASK_TXT),
 	customText(&mutant_rejection, talky + CONST_MUTANT_REJECTION_TXT),
 	customText(&that_is_disturbing, talky + CONST_THAT_IS_DISTURBING_TXT),
 	customText(&that_is_not_disturbing, talky + CONST_THAT_IS_NOT_DISTURBING_TXT),
@@ -5592,11 +5594,13 @@ void printAcceptsPickupLine(const string aname, const string tkname, const vecto
 	addstrAlt(unnamed_String_Talk_cpp_073, gamelog);
 	gamelog.newline();
 }
+// Messed with that a bit to make the mask comments appear nicely.
 void printRejectsPickupLine(const string tkname, const int tktype, const int agender_liberal, const vector<string> selected_flirt) {
 
 	const bool extraline = (selected_flirt[1].empty() ?  0 : 1);
-	int y = 13 + (extraline ? 1 : 0);
-	printRespondantName(tkname, extraline);
+	int y = 15 + (extraline ? 1 : 0);
+	set_color_easy(WHITE_ON_BLACK_BRIGHT);
+	mvaddstrAlt(14, 1, tkname + " responds,", gamelog);
 	set_color_easy(RED_ON_BLACK_BRIGHT);
 	if (tktype == CREATURE_CORPORATE_CEO)
 	{
@@ -5620,16 +5624,30 @@ void printSaysWhat(const string tkname) {
 	mvaddstrAlt(13, 1, CONST_WHAT, gamelog);
 	gamelog.newline();
 }
+//Used to get comments on masks and concealed faces.
+void printWeirdMask(const string tkname, const int tkalign, const int line) {
+	set_color_easy(WHITE_ON_BLACK_BRIGHT);
+	mvaddstrAlt(line, 1, tkname+" responds,", gamelog);
+	set_color_easy(CYAN_ON_BLACK_BRIGHT);
+	mvaddstrAlt(line, len(tkname)+12, pickrandom(WeirdMask), gamelog);
+	set_color_easy(WHITE_ON_BLACK_BRIGHT);
+	gamelog.newline();
+	mvaddstrAlt(line+1, 1, tkname, gamelog);
+	printLooksAtSquadSuspiciously();
+	gamelog.newline();
+}
+// Had to mess around with this a bit to get it to display correctly with the new Mask comment.
 void printTurnsAway(const string tkname, const int tkalign) {
-	printRespondantName(tkname);
+	set_color_easy(WHITE_ON_BLACK_BRIGHT);
+	mvaddstrAlt(13, 1, tkname + " responds,", gamelog);
 	set_color_easy(CYAN_ON_BLACK_BRIGHT);
 	if (isPrisoner(tkname))
 	{
 		if (tkalign == ALIGN_LIBERAL)
-			mvaddstrAlt(13, 1, CONST_NOW_S_NOT_THE_TIME, gamelog);
-		else mvaddstrAlt(13, 1, CONST_LEAVE_ME_ALONE, gamelog);
+			mvaddstrAlt(13, len(tkname)+12, CONST_NOW_S_NOT_THE_TIME, gamelog);
+		else mvaddstrAlt(13, len(tkname)+12, CONST_LEAVE_ME_ALONE, gamelog);
 	}
-	else mvaddstrAlt(13, 1, unnamed_String_Talk_cpp_064, gamelog);
+	else mvaddstrAlt(13, len(tkname)+12, unnamed_String_Talk_cpp_064, gamelog);
 	set_color_easy(WHITE_ON_BLACK_BRIGHT);
 	addstrAlt(unnamed_String_Talk_cpp_065, gamelog);
 	gamelog.newline();

--- a/src/daily/activities.cpp
+++ b/src/daily/activities.cpp
@@ -685,8 +685,11 @@ void doActivitySellBrownies(vector<DeprecatedCreature *> &brownies, char &clearf
 		//Check for police search
 		int dodgelawroll = LCSrandom(1 + 30 * lawList[LAW_DRUGS] + 3);
 		//Saved by street sense?
-		if (dodgelawroll == 0)
+		if (dodgelawroll == 0 && !brownies[s]->face_is_concealed())
 			dodgelawroll = brownies[s]->skill_check(SKILL_STREETSENSE, DIFFICULTY_AVERAGE);
+		//Masks kinda stand out
+		if (dodgelawroll == 0 && brownies[s]->face_is_concealed())
+			dodgelawroll = brownies[s]->skill_check(SKILL_STREETSENSE, DIFFICULTY_HARD);
 		if (dodgelawroll == 0 && lawList[LAW_DRUGS] <= 0) // Busted!
 		{
 			Deprecatednewsstoryst *ns = new Deprecatednewsstoryst;

--- a/src/daily/date.cpp
+++ b/src/daily/date.cpp
@@ -544,6 +544,12 @@ This file is part of Liberal Crime Squad.                                       
 					 troll += d.date[e]->skill_roll(SKILL_SCIENCE);
 					 aroll += pool[p]->skill_roll(SKILL_SCIENCE);
 				 }
+				 // Going on a date while masked can turn some people off.
+				 if (pool[p]->face_is_concealed())
+				 {
+					 printWeirdMask(d.date[e]->name, d.date[e]->align, 16);
+					 aroll -= LCSrandom(5);
+				 }
 				 int y = 17;
 				 if (dateresult(aroll, troll, d, e, p, y) == DATERESULT_ARRESTED) return 1;
 				 break;

--- a/src/daily/siege.cpp
+++ b/src/daily/siege.cpp
@@ -244,7 +244,7 @@ void surrenderToAuthorities(const int loc) {
 	if (kcount) criminalizepool(LAWFLAG_KIDNAPPING, -1, loc);
 	if (icount) criminalizepool(LAWFLAG_HIREILLEGAL, -1, loc);
 	if (LocationsPool::getInstance().getSiegeType(loc) == SIEGE_FIREMEN && hasPrintingPress(loc))
-		criminalizepool(LAWFLAG_SPEECH, -1, loc); // Criminalize pool for unacceptable speech
+		criminalizepress(LAWFLAG_SPEECH, -1, loc); // Criminalize press for unacceptable speech
 												  //LOOK FOR PRISONERS (MUST BE AFTER CRIMINALIZATION ABOVE)
 	for (int p = CreaturePool::getInstance().lenpool() - 1; p >= 0; p--)
 	{

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -202,7 +202,8 @@ string fixLineSpecialCharacter(char * toFix) {
 			case -70: // 'ú'
 				c = (char)0xa3;
 				break;
-			case (int) '¼':
+// The following cases causes compile error when compiling with Japanese Local in the machine because of the int variable.
+			case (int)'¼':
 				// 'ü'
 				c = (char)0x81;
 				break;
@@ -217,7 +218,7 @@ string fixLineSpecialCharacter(char * toFix) {
 			case (int) '¢':
 				// 'â'
 				c = (char)0x83;
-				break;
+				break; 
 			default:
 				c = toFix[i];
 				break;

--- a/src/includes07.h
+++ b/src/includes07.h
@@ -1214,6 +1214,7 @@ void printHostageNegotiation(const string ename, const int etype, const int eali
 void printReleaseHostagesFooter(const int hostages);
 void printLetUsGoAndTheyGoFree(const string aname, const int hostages);
 void printTurnsAway(const string tkname, const int tkalign);
+void printWeirdMask(const string tkname, const int tkalign, const int line);
 void printAnimalDoesntUnderstand(const string tkname, const int tktype);
 void printThreatensWithAGun(const string aname, const string aweapon);
 void printINeedThisMuchRent(const string tkname, const int rent);

--- a/src/includes08.h
+++ b/src/includes08.h
@@ -306,7 +306,7 @@ extern short sitealienate;
 extern short sitetype;
 extern siteblockst levelmap[MAPX][MAPY][MAPZ];
 
-
+void printWeirdMask(const string tkname, const int tkalign, const int line); // Needed that for Mask suspicion.
 void printShoutsForHelp(const string ename, const int ealign);
 bool isPrisoner(const string tkname);
 void printAlienation(const short sitealienate);

--- a/src/includes43.h
+++ b/src/includes43.h
@@ -125,6 +125,8 @@ enum DateResults
 	DATERESULT_JOINED,
 	DATERESULT_ARRESTED
 };
+//So dates can see masks.
+void printWeirdMask(const string tkname, const int tkalign, const int line);
 int getpoolcreature(int id);
 char completedate(Deprecateddatest &d, int p);
 void removesquadinfo(DeprecatedCreature &cr);

--- a/src/locations/locationsPool.cpp
+++ b/src/locations/locationsPool.cpp
@@ -2155,7 +2155,7 @@ void publishSpecialEditions(char &clearformess) {
 		{
 			if (printnews(loottypeindex, len(nploc))) {
 				for (int l = 0; l < len(nploc); l++)
-					criminalizepool(LAWFLAG_TREASON, -1, nploc[l]);
+					criminalizepress(LAWFLAG_TREASON, -1, nploc[l]);
 			}
 		}
 	}

--- a/src/sitemode/stealth.cpp
+++ b/src/sitemode/stealth.cpp
@@ -395,6 +395,17 @@ This file is part of Liberal Crime Squad.                                       
 	 return uniformed;
  }
 
+ /* checks if a creature's face is covered */
+ char facecheck(const DeprecatedCreature &cr)
+ {
+	 bool concealed = cr.face_is_concealed();
+	 if (concealed)
+	 {
+		 return 1; // Hidden Face, Implement suspicion?
+	 }
+	 return 0; // Face is visible
+ }
+
  /* checks if a creature's weapon is suspicious */
  char weaponcheck(const DeprecatedCreature &cr, bool metaldetect)
  {
@@ -514,6 +525,15 @@ This file is part of Liberal Crime Squad.                                       
 					 {
 						 int result = activesquad->squad[i]->skill_roll(SKILL_DISGUISE);
 						 result -= timer;
+						 // Acting Casual with a mask is harder.
+						 for (int i = 0; i < 6; i++)
+						 {
+							 if (activesquad->squad[i] == NULL) break;
+							 if (facecheck(*activesquad->squad[i]))
+							 {
+								 result -= 1;
+							 }
+						 }
 						 if (fieldskillrate == FIELDSKILLRATE_HARD && result + 1 == disguise_difficulty)
 						 {// Hard more = You only learn if you just missed, and realize what you did wrong.
 							 activesquad->squad[i]->train(SKILL_DISGUISE, 10);
@@ -578,7 +598,19 @@ This file is part of Liberal Crime Squad.                                       
 				 pressAnyKey();
 			 }
 			 else if (!noticed)
-			 {
+			 {	 
+				 // They comment about liberal's suspicious mask.
+				 bool masked = 0;
+				 for (int i = 0; i < 6; i++)
+				 {
+					 if (activesquad->squad[i] == NULL) break;
+					 if (facecheck(*activesquad->squad[i]))
+					 {
+						 masked = 1;
+					 }
+				 }
+				 if (masked)
+					 printWeirdMask(encounter[n].name, encounter[n].align, 17);
 				 printActsNatural(activesquad->squad[0]->getNameAndAlignment().name, partysize);
 				 pressAnyKey();
 			 }
@@ -596,8 +628,21 @@ This file is part of Liberal Crime Squad.                                       
 				 setSiteAlarmOne();
 			 }
 			 else
-			 {
-				 printLooksAtSquadSuspiciously();
+			 {	 
+				 // They comment about liberal's suspicious mask.
+				 bool masked = 0;
+				 for (int i = 0; i < 6; i++)
+				 {
+					 if (activesquad->squad[i] == NULL) break;
+					 if (facecheck(*activesquad->squad[i]))
+					 {
+						 masked = 1;
+					 }
+				 }
+				 if (masked)
+					 printWeirdMask(encounter[n].name, encounter[n].align, 17);
+				 else
+					 printLooksAtSquadSuspiciously();
 				 int time = get_encounter_time(n);
 				 if (time < 1)time = 1;
 				 if (sitealarmtimer > time || sitealarmtimer == -1)sitealarmtimer = time;

--- a/src/sitemode/talk.cpp
+++ b/src/sitemode/talk.cpp
@@ -424,7 +424,12 @@ void wannaHearSomethingDisturbing(DeprecatedCreature &a, DeprecatedCreature &tk)
 	printCommonXeDoesStatement(eprintWannaHearSomething,a.getNameAndAlignment().name);
 	pressAnyKey();
 	bool interested = tk.talkreceptive();
-	if (!interested && a.skill_check(SKILL_PERSUASION, DIFFICULTY_AVERAGE))
+	if (!interested && !a.face_is_concealed() && a.skill_check(SKILL_PERSUASION, DIFFICULTY_AVERAGE))
+	{
+		interested = true;
+	}
+	// It's a bit harder to get people to trust a liberal with a mask.
+	if (!interested && a.face_is_concealed() && a.skill_check(SKILL_PERSUASION, DIFFICULTY_CHALLENGING))
 	{
 		interested = true;
 	}
@@ -442,6 +447,11 @@ void wannaHearSomethingDisturbing(DeprecatedCreature &a, DeprecatedCreature &tk)
 	}
 	else
 	{
+		if (a.face_is_concealed()) //They comment on liberal's mask.
+		{
+			printWeirdMask(tk.getNameAndAlignment().name, tk.align, 11);
+			pressAnyKey();
+		}
 		printTurnsAway(tk.getNameAndAlignment().name, tk.align);
 		pressAnyKey();
 	}
@@ -467,6 +477,9 @@ void doYouComeHereOften(DeprecatedCreature &a, DeprecatedCreature &tk)
 		difficulty = DIFFICULTY_HEROIC;
 	const bool is_naked = a.is_naked_human();
 	if (is_naked) difficulty -= 4;
+	// Harder to pick up people while looking sus.
+	const bool face_hidden = a.face_is_concealed();
+	if (face_hidden) difficulty += 4;
 	if (a.skill_check(SKILL_SEDUCTION, difficulty))
 		succeeded = true;
 	if ((tk.animalgloss == ANIMALGLOSS_ANIMAL && lawList[LAW_ANIMALRESEARCH] != 2 && a.animalgloss != ANIMALGLOSS_ANIMAL) ||
@@ -511,6 +524,12 @@ void doYouComeHereOften(DeprecatedCreature &a, DeprecatedCreature &tk)
 	}
 	else
 	{
+		// They will comment on your mask.
+		if (face_hidden)
+		{
+			printWeirdMask(tk.getNameAndAlignment().name, tk.align, 12);
+			pressAnyKey();
+		}
 		printRejectsPickupLine(tk.getNameAndAlignment().name, tk.type, a.gender_liberal, selected_flirt);
 		pressAnyKey();
 		tk.make_cantbluff_one();


### PR DESCRIPTION
My coding isn't the best, but I thought this would be cool things, use as you see fit.

**Mask Overhaul**:
	-Made concealed faces protect against heat from crimes, unless those crimes are hacking or writing related. (Untested)
	-Made brownie sellers more likely to be accosted by the police while on the job if they wear a mask.(Untested)
	-Made it a bit harder for people to hear a liberal out when they wear a mask. They'll turn away more often and should comment about it when they do. (Tested)
	-Made Pick-Up lines harder when liberal is wearing a mask, People'll also comment on it when they reject the liberal.(Tested.)
	-Dates will comment on your mask, and it will have more chance to go awry.(Tested)
	-Acting Casual during infiltration while masked is harder and they will comment about it.(Tested)
	-Comments about masks are randomized from a .txt file in the art folder.(Tested)
	
**Newspaper Changes**:	
	-Made Newspaper related treason and speech crimes only affect writers. (Untested)
	-Made it criminalize the location as it was before if no writers are found. (Untested.)
	
**Clothing**:
	-Made a Black Block Outfit, hides face and provide some stealth, not found in shops but craftable for 30$. (Just works.)
	-Made an Armored version of the Black Block Outfit, stats based on Black Leather Armor, not found in shop either, craftable for 350$. (Just works.)